### PR TITLE
Test base2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,17 +175,17 @@ pipeline {
         }
         stage('Run GFE Integeration Tests') {
             steps {
-                sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py short'
+                sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py'
                 run_pytest('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 1200, 'GFE_Integration', 'auto')
             }
         }
         stage('Run IntroLab Integration Tests') {
             steps {
-                sh 'python IntroLab/integration_tests/script_builder.py short'
+                sh 'python IntroLab/integration_tests/script_builder.py'
                 run_pytest('IntroLab/integration_tests', 1200, 'IntroLab_Integration', 'auto')
             }
         }
-        stage('Run PyNN8Examples Integration Tests LONG') {
+        stage('Run PyNN8Examples Integration Tests') {
             steps {
                 sh 'python PyNN8Examples/integration_tests/script_builder.py'
                 run_pytest('PyNN8Examples/integration_tests', 1200, 'PyNN8Examples_Integration', 'auto')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,7 @@ pipeline {
         }
         stage('Run GFE Integeration Tests') {
             steps {
+                sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py short'
                 run_pytest('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 1200, 'GFE_Integration', 'auto')
             }
         }
@@ -209,7 +210,7 @@ pipeline {
         }
         stage('Check Destroyed') {
             steps {
-                sh 'py.test sPyNNaker/p8_integration_tests/destroyed_checker_test --forked --instafail --timeout 120'
+                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy --forked --instafail --timeout 120'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,7 @@ pipeline {
         }
         stage('Check Destroyed') {
             steps {
-                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy --forked --instafail --timeout 120'
+                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy.py --forked --instafail --timeout 120'
             }
         }
     }

--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -211,7 +211,7 @@ pipeline {
         }
         stage('Check Destroyed') {
             steps {
-                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy --forked --instafail --timeout 120'
+                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy.py --forked --instafail --timeout 120'
             }
         }
     }

--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -173,6 +173,7 @@ pipeline {
         }
         stage('Run GFE Integeration Tests') {
             steps {
+                sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py short'
                 run_pytest_single('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 1200, 'GFE_Integration', 'integration')
             }
         }
@@ -201,7 +202,7 @@ pipeline {
         }
         stage('Check Destroyed') {
             steps {
-                sh 'py.test sPyNNaker/p8_integration_tests/destroyed_checker_test --forked --instafail --timeout 120'
+                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy --forked --instafail --timeout 120'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # IntegrationTests
 Integration Tests unified over all repositories
 
+
 In particular, tests:
 * [sPyNNaker](https://github.com/SpiNNakerManchester/sPyNNaker)
 * [SpiNNaker Graph Front End](https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd)


### PR DESCRIPTION
Use Testbase for GraphFrontEnd and many other test cleanups

Depends on:
https://github.com/SpiNNakerManchester/TestBase/pull/2
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/176
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1018
https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/70
