### PR TITLE
Fix job name issue in cron job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         // This is where 'pip install --user' puts things
         PATH = "$HOME/.local/bin:$PATH"
         BINARY_LOGS_DIR = "${workspace}"
-        THE_JOB = "${JOB_NAME.substring(0, JOB_NAME.lastIndexOf('/'))}"
+        THE_JOB = getJobName()
     }
     options {
         skipDefaultCheckout true
@@ -325,4 +325,13 @@ def getGitBranchName() {
     dir('IntegrationTests') {
         return sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
     }
+}
+
+def getJobName() {
+    def index = env.JOB_NAME.lastIndexOf('/')
+    if (index == -1) {
+        index = env.JOB_NAME.length()
+    }
+
+    return env.JOB_NAME.substring(0, index)
 }


### PR DESCRIPTION
After editing the cron job to run this branch, it appears the fix works:
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration_Tests_Cron_Job/detail/Integration_Tests_Cron_Job/622/pipeline

Note that I aborted the run today, but the name displayed should run the whole test from what I can see.