### PR TITLE
Allow abort

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,14 +188,14 @@ pipeline {
         }
         stage('Run sPyNNaker Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('sPyNNaker/spynnaker_integration_tests/', 24000, 'sPyNNaker_Integration_Tests', 'integration', 'auto')
                 }
             }
         }
         stage('Run GFE Integeration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py'
                     run_pytest('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 3600, 'GFE_Integration', 'integration', 'auto')
                 }
@@ -203,7 +203,7 @@ pipeline {
         }
         stage('Run IntroLab Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python IntroLab/integration_tests/script_builder.py'
                     run_pytest('IntroLab/integration_tests', 3600, 'IntroLab_Integration', 'integration', 'auto')
                 }
@@ -211,7 +211,7 @@ pipeline {
         }
         stage('Run PyNN8Examples Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                   sh 'python PyNN8Examples/integration_tests/script_builder.py'
                   run_pytest('PyNN8Examples/integration_tests', 3600, 'PyNN8Examples_Integration', 'integration', 'auto')
               }
@@ -219,7 +219,7 @@ pipeline {
         }
         stage('Run sPyNNaker8NewModelTemplate Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python sPyNNaker8NewModelTemplate/nmt_integration_tests/script_builder.py'
                     run_pytest('sPyNNaker8NewModelTemplate/nmt_integration_tests', 3600, 'sPyNNaker8NewModelTemplate_Integration', 'integration', 'auto')
                 }
@@ -227,14 +227,14 @@ pipeline {
         }
         stage('Run microcircuit_model Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('microcircuit_model/integration_tests', 12000, 'microcircuit_model_Integration', 'integration', 'auto')
                 }
             }
         }
         stage('Run SpiNNGym Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNGym/integration_tests/script_builder.py'
                     run_pytest('SpiNNGym/integration_tests', 3600, 'SpiNNGym_Integration', 'integration', 'auto')
                 }
@@ -242,7 +242,7 @@ pipeline {
         }
         stage('Run MarkovChainMonteCarlo Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python MarkovChainMonteCarlo/mcmc_integration_tests/script_builder.py'
                     run_pytest('MarkovChainMonteCarlo/mcmc_integration_tests', 3600, 'MarkovChainMonteCarlo_Integration', 'integration', 'auto')
                 }
@@ -250,7 +250,7 @@ pipeline {
         }
         stage('Run SpiNNaker_PDP2 Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNaker_PDP2/integration_tests/script_builder.py'
                     run_pytest('SpiNNaker_PDP2/integration_tests', 3600, 'SpiNNaker_PDP2_Integration', 'integration', 'auto')
                 }
@@ -258,7 +258,7 @@ pipeline {
         }
         stage('Run Visualiser Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('Visualiser/visualiser_integration_tests', 12000, 'visualiser_Integration', 'integration', 'auto')
                 }
             }
@@ -268,7 +268,7 @@ pipeline {
                 environment name: 'THE_JOB', value: 'Integration_Tests_Cron_Job'
             }
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('sPyNNaker/test_whole_board', 12000, 'test_whole_machine', 'integration', '16')
                 }
             }


### PR DESCRIPTION
Minor change to allow someone to press "stop" and not have to then do that again with all the following tests!

Evidence of this working include the following:
 - Before change: I had to stop each bit one-by-one.  You can see that each stage was started and aborted here: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/extdev_fpgas/22/pipeline
 - After change: A failure in the first protected stage made me want to stop and restart tests.  You can see a run where the remaining tests are skipped after the abort here (I made the change on another branch first): http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/extdev_fpgas/23/pipeline
 - After change: Proof that it still goes past a failure if one happens, but aborting then stops the remaining stages from the abort.  In this one, I forced a failure by killing a spalloc job, then waiting until it started the next stage before aborting.  You can see it starts the next stage and then skips the rest after the abort here: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/allow_abort_test/1/pipeline