### PR TITLE
Allow abort and restart tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
                 sh 'mkdir junit/'
             }
         }
-        stage('Unit Tests') {
+        /*stage('Unit Tests') {
             steps {
                 run_pytest('SpiNNUtils/unittests', 1200, 'SpiNNUtils', 'unit', 'auto')
                 run_pytest('SpiNNMachine/unittests', 1200, 'SpiNNMachine', 'unit', 'auto')
@@ -185,7 +185,7 @@ pipeline {
                 run_pytest('SpiNNaker_PDP2/unittests', 1200, 'SpiNNaker_PDP2', 'unit', 'auto')
                 sh "python -m spinn_utilities.executable_finder"
             }
-        }
+        } */
         stage('Run sPyNNaker Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
                 sh 'git clone https://github.com/SpiNNakerManchester/SupportScripts.git support'
                 sh 'pip3 install --upgrade "setuptools<59.8" wheel'
                 sh 'pip install --user --upgrade pip'
+                sh 'pip install virtualenv'
                 // SpiNNakerManchester internal dependencies; development mode
                 sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/SpiNNUtils.git'
                 sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/SpiNNMachine.git'
@@ -82,53 +83,55 @@ pipeline {
                 NEURAL_MODELLING_DIRS = "${workspace}/sPyNNaker/neural_modelling"
             }
             steps {
+                // Make a virtualenv
+                sh 'virtualenv pyenv'
                 // Install SpiNNUtils first as needed for C build
-                sh 'cd SpiNNUtils && python setup.py develop'
+                run_in_pyenv('cd SpiNNUtils && python setup.py develop')
                 // C Build next as builds files to be installed in Python
-                sh 'make -C $SPINN_DIRS'
-                sh 'make -C spinn_common install'
-                sh 'make -C SpiNNFrontEndCommon/c_common'
-                sh 'make -C SpiNNFrontEndCommon/c_common install'
-                sh 'make -C sPyNNaker/neural_modelling'
-                sh 'make -C sPyNNaker8NewModelTemplate/c_models'
-                sh 'make -C SpiNNakerGraphFrontEnd/gfe_examples'
-                sh 'make -C SpiNNakerGraphFrontEnd/gfe_integration_tests/'
-                sh 'make -C SpiNNGym/c_code'
-                sh 'make -C MarkovChainMonteCarlo/c_models'
-                sh 'make -C SpiNNaker_PDP2/c_code'
-                sh 'make -C Visualiser'
+                run_in_pyenv('make -C $SPINN_DIRS')
+                run_in_pyenv('make -C spinn_common install')
+                run_in_pyenv('make -C SpiNNFrontEndCommon/c_common')
+                run_in_pyenv('make -C SpiNNFrontEndCommon/c_common install')
+                run_in_pyenv('make -C sPyNNaker/neural_modelling')
+                run_in_pyenv('make -C sPyNNaker8NewModelTemplate/c_models')
+                run_in_pyenv('make -C SpiNNakerGraphFrontEnd/gfe_examples')
+                run_in_pyenv('make -C SpiNNakerGraphFrontEnd/gfe_integration_tests/')
+                run_in_pyenv('make -C SpiNNGym/c_code')
+                run_in_pyenv('make -C MarkovChainMonteCarlo/c_models')
+                run_in_pyenv('make -C SpiNNaker_PDP2/c_code')
+                run_in_pyenv('make -C Visualiser')
                 // Python install
-                sh 'cd SpiNNMachine && python setup.py develop'
-                sh 'cd SpiNNMan && python setup.py develop'
-                sh 'cd PACMAN && python setup.py develop'
-                sh 'cd DataSpecification && python setup.py develop'
-                sh 'cd spalloc && python setup.py develop'
-                sh 'cd SpiNNFrontEndCommon && python setup.py develop'
-                sh 'cd sPyNNaker && python setup.py develop'
-                sh 'cd sPyNNaker8NewModelTemplate && python ./setup.py develop'
-                sh 'cd SpiNNakerGraphFrontEnd && python ./setup.py develop'
-                sh 'cd SpiNNGym && python ./setup.py develop'
-                sh 'cd MarkovChainMonteCarlo && python ./setup.py develop'
-                sh 'cd TestBase && python ./setup.py develop'
-                sh 'cd SpiNNaker_PDP2 && python ./setup.py develop'
-                sh 'cd Visualiser && python ./setup.py develop'
-                sh 'python -m spynnaker.pyNN.setup_pynn'
+                run_in_pyenv('cd SpiNNMachine && python setup.py develop')
+                run_in_pyenv('cd SpiNNMan && python setup.py develop')
+                run_in_pyenv('cd PACMAN && python setup.py develop')
+                run_in_pyenv('cd DataSpecification && python setup.py develop')
+                run_in_pyenv('cd spalloc && python setup.py develop')
+                run_in_pyenv('cd SpiNNFrontEndCommon && python setup.py develop')
+                run_in_pyenv('cd sPyNNaker && python setup.py develop')
+                run_in_pyenv('cd sPyNNaker8NewModelTemplate && python ./setup.py develop')
+                run_in_pyenv('cd SpiNNakerGraphFrontEnd && python ./setup.py develop')
+                run_in_pyenv('cd SpiNNGym && python ./setup.py develop')
+                run_in_pyenv('cd MarkovChainMonteCarlo && python ./setup.py develop')
+                run_in_pyenv('cd TestBase && python ./setup.py develop')
+                run_in_pyenv('cd SpiNNaker_PDP2 && python ./setup.py develop')
+                run_in_pyenv('cd Visualiser && python ./setup.py develop')
+                run_in_pyenv('python -m spynnaker.pyNN.setup_pynn')
                 // Test requirements
-                sh 'pip install -r SpiNNMachine/requirements-test.txt'
-                sh 'pip install -r SpiNNMan/requirements-test.txt'
-                sh 'pip install -r PACMAN/requirements-test.txt'
-                sh 'pip install -r DataSpecification/requirements-test.txt'
-                sh 'pip install -r spalloc/requirements-test.txt'
-                sh 'pip install -r SpiNNFrontEndCommon/requirements-test.txt'
-                sh 'pip install -r sPyNNaker/requirements-test.txt'
-                sh 'pip install -r SpiNNakerGraphFrontEnd/requirements-test.txt'
-                sh 'pip install -r SpiNNGym/requirements-test.txt'
-                sh 'pip install -r MarkovChainMonteCarlo/requirements-test.txt'
-                sh 'pip install -r SpiNNaker_PDP2/requirements-test.txt'
+                run_in_pyenv('pip install -r SpiNNMachine/requirements-test.txt')
+                run_in_pyenv('pip install -r SpiNNMan/requirements-test.txt')
+                run_in_pyenv('pip install -r PACMAN/requirements-test.txt')
+                run_in_pyenv('pip install -r DataSpecification/requirements-test.txt')
+                run_in_pyenv('pip install -r spalloc/requirements-test.txt')
+                run_in_pyenv('pip install -r SpiNNFrontEndCommon/requirements-test.txt')
+                run_in_pyenv('pip install -r sPyNNaker/requirements-test.txt')
+                run_in_pyenv('pip install -r SpiNNakerGraphFrontEnd/requirements-test.txt')
+                run_in_pyenv('pip install -r SpiNNGym/requirements-test.txt')
+                run_in_pyenv('pip install -r MarkovChainMonteCarlo/requirements-test.txt')
+                run_in_pyenv('pip install -r SpiNNaker_PDP2/requirements-test.txt')
                 // Additional requirements for testing here
                 // coverage version capped due to https://github.com/nedbat/coveragepy/issues/883
-                sh 'pip install python-coveralls "coverage>=5.0.0"'
-                sh 'pip install pytest-instafail "pytest-xdist==1.34.0"'
+                run_in_pyenv('pip install python-coveralls "coverage>=5.0.0"')
+                run_in_pyenv('pip install pytest-instafail "pytest-xdist==1.34.0"')
                 // Java install
                 sh 'mvn -f JavaSpiNNaker package'
             }
@@ -168,7 +171,7 @@ pipeline {
                 sh 'mkdir junit/'
             }
         }
-        /*stage('Unit Tests') {
+        stage('Unit Tests') {
             steps {
                 run_pytest('SpiNNUtils/unittests', 1200, 'SpiNNUtils', 'unit', 'auto')
                 run_pytest('SpiNNMachine/unittests', 1200, 'SpiNNMachine', 'unit', 'auto')
@@ -183,9 +186,9 @@ pipeline {
                 run_pytest('SpiNNGym/unittests', 1200, 'SpiNNGym', 'unit', 'auto')
                 run_pytest('MarkovChainMonteCarlo/unittests', 1200, 'SpiNNaker_PDP2', 'unit', 'auto')
                 run_pytest('SpiNNaker_PDP2/unittests', 1200, 'SpiNNaker_PDP2', 'unit', 'auto')
-                sh "python -m spinn_utilities.executable_finder"
+                run_in_pyenv('python -m spinn_utilities.executable_finder')
             }
-        } */
+        }
         stage('Run sPyNNaker Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
@@ -196,7 +199,7 @@ pipeline {
         stage('Run GFE Integeration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py'
+                    run_in_pyenv('python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py')
                     run_pytest('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 3600, 'GFE_Integration', 'integration', 'auto')
                 }
             }
@@ -204,7 +207,7 @@ pipeline {
         stage('Run IntroLab Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python IntroLab/integration_tests/script_builder.py'
+                    run_in_pyenv('python IntroLab/integration_tests/script_builder.py')
                     run_pytest('IntroLab/integration_tests', 3600, 'IntroLab_Integration', 'integration', 'auto')
                 }
             }
@@ -212,7 +215,7 @@ pipeline {
         stage('Run PyNN8Examples Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                  sh 'python PyNN8Examples/integration_tests/script_builder.py'
+                  run_in_pyenv('python PyNN8Examples/integration_tests/script_builder.py')
                   run_pytest('PyNN8Examples/integration_tests', 3600, 'PyNN8Examples_Integration', 'integration', 'auto')
               }
             }
@@ -220,7 +223,7 @@ pipeline {
         stage('Run sPyNNaker8NewModelTemplate Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python sPyNNaker8NewModelTemplate/nmt_integration_tests/script_builder.py'
+                    run_in_pyenv('python sPyNNaker8NewModelTemplate/nmt_integration_tests/script_builder.py')
                     run_pytest('sPyNNaker8NewModelTemplate/nmt_integration_tests', 3600, 'sPyNNaker8NewModelTemplate_Integration', 'integration', 'auto')
                 }
             }
@@ -235,7 +238,7 @@ pipeline {
         stage('Run SpiNNGym Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python SpiNNGym/integration_tests/script_builder.py'
+                    run_in_pyenv('python SpiNNGym/integration_tests/script_builder.py')
                     run_pytest('SpiNNGym/integration_tests', 3600, 'SpiNNGym_Integration', 'integration', 'auto')
                 }
             }
@@ -243,7 +246,7 @@ pipeline {
         stage('Run MarkovChainMonteCarlo Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python MarkovChainMonteCarlo/mcmc_integration_tests/script_builder.py'
+                    run_in_pyenv('python MarkovChainMonteCarlo/mcmc_integration_tests/script_builder.py')
                     run_pytest('MarkovChainMonteCarlo/mcmc_integration_tests', 3600, 'MarkovChainMonteCarlo_Integration', 'integration', 'auto')
                 }
             }
@@ -251,7 +254,7 @@ pipeline {
         stage('Run SpiNNaker_PDP2 Integration Tests') {
             steps {
                 catchError(stageResult: 'FAILURE', catchInterruptions: false) {
-                    sh 'python SpiNNaker_PDP2/integration_tests/script_builder.py'
+                    run_in_pyenv('python SpiNNaker_PDP2/integration_tests/script_builder.py')
                     run_pytest('SpiNNaker_PDP2/integration_tests', 3600, 'SpiNNaker_PDP2_Integration', 'integration', 'auto')
                 }
             }
@@ -276,12 +279,12 @@ pipeline {
         stage('Reports') {
             steps {
                 sh 'find . -maxdepth 3 -type f -wholename "*/reports/*" -print -exec cat \\{\\}  \\;'
-                sh "python -m spinn_utilities.executable_finder"
+                run_in_pyenv('python -m spinn_utilities.executable_finder')
             }
         }
         stage('Check Destroyed') {
             steps {
-                sh 'py.test TestBase/spinnaker_testbase/test_no_job_destroy.py --forked --instafail --timeout 120'
+                run_in_pyenv('py.test TestBase/spinnaker_testbase/test_no_job_destroy.py --forked --instafail --timeout 120')
             }
         }
     }
@@ -314,14 +317,19 @@ def run_pytest(String tests, int timeout, String results, String covfile, String
     def resfile = 'junit/' + results + '.xml'
     covfile += '_cov.xml'
     sh 'echo "<testsuite tests="0"></testsuite>" > ' + resfile
-    sh 'py.test ' + tests +
+    run_in_pyenv('py.test ' + tests +
         ' -rs -n ' + threads + ' --forked --show-progress --cov-config=.coveragerc --cov-branch ' +
         '--cov spynnaker8 --cov spynnaker --cov spinn_front_end_common --cov pacman ' +
         '--cov data_specification --cov spinnman --cov spinn_machine --cov spalloc ' +
         '--cov spinn_utilities --cov spinnaker_graph_front_end ' +
         '--junitxml ' + resfile + ' --cov-report xml:' + covfile + ' --cov-append ' +
-        '--timeout ' + timeout + ' --log-level=INFO '
+        '--timeout ' + timeout + ' --log-level=INFO ')
 }
+
+def run_in_pyenv(String command) {
+    sh script:'source ${WORKSPACE}/pyenv/bin/activate && ' + command, label: command
+}
+
 
 def getGitBranchName() {
     if (env.BRANCH_NAME) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,14 +188,14 @@ pipeline {
         }
         stage('Run sPyNNaker Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('sPyNNaker/spynnaker_integration_tests/', 24000, 'sPyNNaker_Integration_Tests', 'integration', 'auto')
                 }
             }
         }
         stage('Run GFE Integeration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNakerGraphFrontEnd/gfe_integration_tests/script_builder.py'
                     run_pytest('SpiNNakerGraphFrontEnd/gfe_integration_tests/', 3600, 'GFE_Integration', 'integration', 'auto')
                 }
@@ -203,7 +203,7 @@ pipeline {
         }
         stage('Run IntroLab Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python IntroLab/integration_tests/script_builder.py'
                     run_pytest('IntroLab/integration_tests', 3600, 'IntroLab_Integration', 'integration', 'auto')
                 }
@@ -211,7 +211,7 @@ pipeline {
         }
         stage('Run PyNN8Examples Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                   sh 'python PyNN8Examples/integration_tests/script_builder.py'
                   run_pytest('PyNN8Examples/integration_tests', 3600, 'PyNN8Examples_Integration', 'integration', 'auto')
               }
@@ -219,7 +219,7 @@ pipeline {
         }
         stage('Run sPyNNaker8NewModelTemplate Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python sPyNNaker8NewModelTemplate/nmt_integration_tests/script_builder.py'
                     run_pytest('sPyNNaker8NewModelTemplate/nmt_integration_tests', 3600, 'sPyNNaker8NewModelTemplate_Integration', 'integration', 'auto')
                 }
@@ -227,14 +227,14 @@ pipeline {
         }
         stage('Run microcircuit_model Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('microcircuit_model/integration_tests', 12000, 'microcircuit_model_Integration', 'integration', 'auto')
                 }
             }
         }
         stage('Run SpiNNGym Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNGym/integration_tests/script_builder.py'
                     run_pytest('SpiNNGym/integration_tests', 3600, 'SpiNNGym_Integration', 'integration', 'auto')
                 }
@@ -242,7 +242,7 @@ pipeline {
         }
         stage('Run MarkovChainMonteCarlo Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python MarkovChainMonteCarlo/mcmc_integration_tests/script_builder.py'
                     run_pytest('MarkovChainMonteCarlo/mcmc_integration_tests', 3600, 'MarkovChainMonteCarlo_Integration', 'integration', 'auto')
                 }
@@ -250,7 +250,7 @@ pipeline {
         }
         stage('Run SpiNNaker_PDP2 Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     sh 'python SpiNNaker_PDP2/integration_tests/script_builder.py'
                     run_pytest('SpiNNaker_PDP2/integration_tests', 3600, 'SpiNNaker_PDP2_Integration', 'integration', 'auto')
                 }
@@ -258,7 +258,7 @@ pipeline {
         }
         stage('Run Visualiser Integration Tests') {
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('Visualiser/visualiser_integration_tests', 12000, 'visualiser_Integration', 'integration', 'auto')
                 }
             }
@@ -268,7 +268,7 @@ pipeline {
                 environment name: 'THE_JOB', value: 'Integration_Tests_Cron_Job'
             }
             steps {
-                catchError(stageResult: 'FAILURE') {
+                catchError(stageResult: 'FAILURE', catchInterruptions: false) {
                     run_pytest('sPyNNaker/test_whole_board', 12000, 'test_whole_machine', 'integration', '16')
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,9 @@ pipeline {
             steps {
                 // Make a virtualenv
                 sh 'virtualenv pyenv'
+                run_in_pyenv('pip3 install --upgrade "setuptools<59.8" wheel')
+                run_in_pyenv('pip install --upgrade pip')
+
                 // Install SpiNNUtils first as needed for C build
                 run_in_pyenv('cd SpiNNUtils && python setup.py develop')
                 // C Build next as builds files to be installed in Python

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -321,36 +321,41 @@ def run_pytest(String tests, int timeout, String results, String covfile, String
 }
 
 def create_spynnaker_config() {
-    if (!fileExists('~/.spynnaker.cfg')) {
-        // Write a sPyNNaker config file for spalloc and java use
-        sh 'echo "[Machine]" > ~/.spynnaker.cfg'
-        sh 'echo "spalloc_server = 10.11.192.11" >> ~/.spynnaker.cfg'
-        sh 'echo "spalloc_user = Jenkins" >> ~/.spynnaker.cfg'
-        sh 'echo "enable_advanced_monitor_support = True" >> ~/.spynnaker.cfg'
-        sh 'echo "[Java]" >> ~/.spynnaker.cfg'
-        sh 'echo "use_java = True" >> ~/.spynnaker.cfg'
-        sh 'echo "java_call=/usr/bin/java" >> ~/.spynnaker.cfg'
-        sh 'echo "java_properties=-Dspinnaker.parallel_tasks=10" >> ~/.spynnaker.cfg'
-        sh 'printf "java_spinnaker_path=" >> ~/.spynnaker.cfg'
-        sh 'pwd >> ~/.spynnaker.cfg'
-    }
+    // Write a sPyNNaker config file for spalloc and java use
+    sh '''
+        if [[ ! -f ~/.spynnaker.cfg ]]
+        then
+            echo "[Machine]" > ~/.spynnaker.cfg
+            echo "spalloc_server = 10.11.192.11" >> ~/.spynnaker.cfg
+            echo "spalloc_user = Jenkins" >> ~/.spynnaker.cfg
+            echo "enable_advanced_monitor_support = True" >> ~/.spynnaker.cfg
+            echo "[Java]" >> ~/.spynnaker.cfg
+            echo "use_java = True" >> ~/.spynnaker.cfg
+            echo "java_call=/usr/bin/java" >> ~/.spynnaker.cfg
+            echo "java_properties=-Dspinnaker.parallel_tasks=10" >> ~/.spynnaker.cfg
+            printf "java_spinnaker_path=" >> ~/.spynnaker.cfg
+            pwd >> ~/.spynnaker.cfg
+        fi
+    '''
 }
 
 def create_gfe_config() {
-    if (!fileExists('~/.spiNNakerGraphFrontEnd')) {
-        // Write a GFE config file for spalloc and java use
-        sh 'echo "[Machine]" > ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "spalloc_server = 10.11.192.11" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "spalloc_user = Jenkins" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "enable_advanced_monitor_support = True" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "[Java]" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "use_java = True" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "java_call=/usr/bin/java" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'echo "java_properties=-Dspinnaker.parallel_tasks=10" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'printf "java_spinnaker_path=" >> ~/.spiNNakerGraphFrontEnd.cfg'
-        sh 'pwd >> ~/.spiNNakerGraphFrontEnd.cfg'
-    }
-
+    // Write a GFE config file for spalloc and java use
+    sh '''
+        if [[ ! -f ~/.spiNNakerGraphFrontEnd.cfg ]]
+        then
+            echo "[Machine]" > ~/.spiNNakerGraphFrontEnd.cfg
+            echo "spalloc_server = 10.11.192.11" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "spalloc_user = Jenkins" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "enable_advanced_monitor_support = True" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "[Java]" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "use_java = True" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "java_call=/usr/bin/java" >> ~/.spiNNakerGraphFrontEnd.cfg
+            echo "java_properties=-Dspinnaker.parallel_tasks=10" >> ~/.spiNNakerGraphFrontEnd.cfg
+            printf "java_spinnaker_path=" >> ~/.spiNNakerGraphFrontEnd.cfg
+            pwd >> ~/.spiNNakerGraphFrontEnd.cfg
+        fi
+    '''
 }
 
 def run_in_pyenv(String command) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,6 +154,8 @@ pipeline {
             steps {
                 // Empty config is sometimes needed in unit tests
                 sh 'echo "# Empty config" >  ~/.spinnaker.cfg'
+                create_spynnaker_config()
+                create_gfe_config()
                 run_pytest('SpiNNUtils/unittests', 1200, 'SpiNNUtils', 'unit', 'auto')
                 run_pytest('SpiNNMachine/unittests', 1200, 'SpiNNMachine', 'unit', 'auto')
                 run_pytest('SpiNNMan/unittests', 1200, 'SpiNNMan', 'unit', 'auto')


### PR DESCRIPTION
Extends #135 by adding the ability to restart tests at each stage too.  It seems that Jenkins will then run all tests from that stage, but it might still save time occasionally.

Note this has been done by adding a virtualenv, and adding a bit to each stage where it writes the config file (it tests for existence first and is quick anyway).  The check of existence is done in a script because this is within a docker container so it can't be done by jenkins directly.  This will then make sure the config exists in each run.