### PR TITLE
Skip building spalloc server in integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ pipeline {
                 run_in_pyenv('pip install python-coveralls "coverage>=5.0.0"')
                 run_in_pyenv('pip install pytest-instafail "pytest-xdist==1.34.0"')
                 // Java install, not server
-                sh 'mvn package -f JavaSpiNNaker -pl -SpiNNaker-allocserv'
+                sh 'mvn package -B -f JavaSpiNNaker -pl -SpiNNaker-allocserv'
             }
         }
         stage('Before Script') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,8 @@ pipeline {
                 // coverage version capped due to https://github.com/nedbat/coveragepy/issues/883
                 run_in_pyenv('pip install python-coveralls "coverage>=5.0.0"')
                 run_in_pyenv('pip install pytest-instafail "pytest-xdist==1.34.0"')
-                // Java install
-                sh 'mvn -f JavaSpiNNaker package'
+                // Java install, not server
+                sh 'mvn package -f JavaSpiNNaker -pl -SpiNNaker-allocserv'
             }
         }
         stage('Before Script') {


### PR DESCRIPTION
This test suite doesn't check the server in itself, because the server has its own deployment complexities, so it shouldn't try to build it either because that runs some tests that take a long time but which are otherwise not relevant.