### PR TITLE
Use the same method for cloning each repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,11 +69,11 @@ pipeline {
                 sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/IntroLab.git'
                 sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/PyNN8Examples.git'
                 sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate.git'
-                sh 'support/gitclone.sh git@github.com:SpiNNakerManchester/microcircuit_model.git'
-                sh 'support/gitclone.sh git@github.com:SpiNNakerManchester/SpiNNGym.git'
-                sh 'support/gitclone.sh git@github.com:SpiNNakerManchester/MarkovChainMonteCarlo.git'
-                sh 'support/gitclone.sh git@github.com:SpiNNakerManchester/TestBase.git'
-                sh 'support/gitclone.sh git@github.com:SpiNNakerManchester/SpiNNaker_PDP2.git'
+                sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/microcircuit_model.git'
+                sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/SpiNNGym.git'
+                sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/MarkovChainMonteCarlo.git'
+                sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/TestBase.git'
+                sh 'support/gitclone.sh https://github.com/SpiNNakerManchester/SpiNNaker_PDP2.git'
             }
         }
         stage('Install') {


### PR DESCRIPTION
Some repositories that used to be private were using a different URL / method when cloning during install, this makes everywhere use the same.