### PR TITLE
Global reports 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     environment {
         // This is where 'pip install --user' puts things
         PATH = "$HOME/.local/bin:$PATH"
-        BINARY_LOGS_DIR = "${workspace}"
+        GLOBAL_REPORTS = "${workspace}/global_reports"
         THE_JOB = getJobName()
     }
     options {
@@ -299,7 +299,7 @@ pipeline {
         }
         stage('Reports') {
             steps {
-                sh 'find . -maxdepth 3 -type f -wholename "*/global_reports/*" -print -exec cat \\{\\}  \\;'
+                sh 'find ${workspace}/global_reports -print -exec cat \\{\\}  \\;'
                 run_in_pyenv('python -m spinn_utilities.executable_finder')
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     environment {
         // This is where 'pip install --user' puts things
         PATH = "$HOME/.local/bin:$PATH"
-        GLOBAL_REPORTS = "${workspace}/global_reports"
+        GLOBAL_REPORTS = "${WORKSPACE}/global_reports"
         THE_JOB = getJobName()
     }
     options {
@@ -32,6 +32,7 @@ pipeline {
                 sh 'echo "Job name is $THE_JOB (from $JOB_NAME)"'
                 sh 'rm -rf ${WORKSPACE}/*'
                 sh 'rm -rf ${WORKSPACE}/.[a-zA-Z0-9]*'
+                sh 'mkdir ${WORKSPACE}/global_reports'
                 dir('IntegrationTests') {
                     checkout scm
                 }
@@ -299,8 +300,8 @@ pipeline {
         }
         stage('Reports') {
             steps {
-                sh 'find ${workspace}/global_reports -print -exec cat \\{\\}  \\;'
                 run_in_pyenv('python -m spinn_utilities.executable_finder')
+                sh 'find ${WORKSPACE}/global_reports -print -exec cat \\{\\}  \\;'
             }
         }
         stage('Check Destroyed') {


### PR DESCRIPTION
The report stage broke because of where testbase was installed.

These PRs create a GLOBAL_REPORTS Environments variable to write the reports to.

If there is no GLOBAL_REPORTS then testbase will use the  FecDataView. get_timestamp_dir_path()

What was BINARY_LOGS_DIR now also uses GLOBAL_REPORTS 
As before if it is not set ExecutableFinder just does not log

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/229
https://github.com/SpiNNakerManchester/TestBase/pull/36

